### PR TITLE
feat: added resolver to user-settings

### DIFF
--- a/descendence/src/app/app-routing.module.ts
+++ b/descendence/src/app/app-routing.module.ts
@@ -26,6 +26,7 @@ import { AcceptComponent } from './accept/accept.component';
 import { LoadcircleComponent } from './accept/loadcircle/loadcircle.component';
 import { SetupGuard } from './setup.guard';
 import { AccountSetupComponent } from './account-setup/account-setup.component';
+import { CurrentUserResolver } from './user-settings/current-user.resolver';
 
 const routes: Routes = [
 	//guard the main page by LoginGuard
@@ -65,6 +66,7 @@ const routes: Routes = [
 			},
 			{
 				path: 'settings',
+				resolve: { user: CurrentUserResolver },
 				component: UserSettingsComponent
 			},
 			{
@@ -121,6 +123,6 @@ const routes: Routes = [
 @NgModule({
 	imports: [RouterModule.forRoot(routes)],
 	exports: [RouterModule],
-	providers: [ LoginGuard, GameGuard, PostGameGuard, chatGuardService, SearchService, chatAdminGuard, PostgameResolver ]
+	providers: [ LoginGuard, GameGuard, PostGameGuard, chatGuardService, SearchService, chatAdminGuard, PostgameResolver, CurrentUserResolver ]
 })
 export class AppRoutingModule { }

--- a/descendence/src/app/user-settings/current-user.resolver.spec.ts
+++ b/descendence/src/app/user-settings/current-user.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CurrentUserResolver } from './current-user.resolver';
+
+describe('CurrentUserResolver', () => {
+  let resolver: CurrentUserResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    resolver = TestBed.inject(CurrentUserResolver);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+});

--- a/descendence/src/app/user-settings/current-user.resolver.ts
+++ b/descendence/src/app/user-settings/current-user.resolver.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import {
+	Router, Resolve,
+	RouterStateSnapshot,
+	ActivatedRouteSnapshot
+} from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { UserEntity, UserService } from '../user.service';
+
+@Injectable({
+	providedIn: 'root'
+})
+export class CurrentUserResolver implements Resolve<UserEntity> {
+	constructor(
+		private readonly userService: UserService
+	) {}
+	resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<UserEntity> {
+		return this.userService.getCurrentUser();
+	}
+}

--- a/descendence/src/app/user-settings/user-settings.component.ts
+++ b/descendence/src/app/user-settings/user-settings.component.ts
@@ -1,6 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input, OnInit } from '@angular/core';
 import { AbstractControl, AsyncValidatorFn, FormControl, FormGroup, ValidationErrors } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { ValidationError } from 'ajv';
 import { Observable, of, timer } from 'rxjs';
 import { delay, filter, first, map, switchMap } from 'rxjs/operators';
@@ -32,7 +33,8 @@ export class UserSettingsComponent implements OnInit {
 		private overlay: FocusOverlayService,
 		private valid: SharedValidatorService,
 		private readonly userService: UserService,
-		private readonly imageService: ImageService
+		private readonly imageService: ImageService,
+		private readonly route: ActivatedRoute,
 	) {
 	}
 	
@@ -177,22 +179,15 @@ export class UserSettingsComponent implements OnInit {
 	}
 
 	ngOnInit(): void {
+		this.currentUserIntra = this.route.snapshot.data.user.intra_name;
+		this.currentAvatarUrl = this.route.snapshot.data.user.avatar_url;
+		this.initialTwoFactorState = this.route.snapshot.data.user.two_factor_enabled;
 		this.settingsForm = new FormGroup({
 			displayName: new FormControl(""),
-			twoFactorEnabled: new FormControl(false),
+			twoFactorEnabled: new FormControl(this.initialTwoFactorState),
 			avatar: new FormControl(""),
 			unblock: new FormControl("")
 		});
 		this.addValidators();
-		//remove me
-		this.settingsForm.controls['twoFactorEnabled'].valueChanges.subscribe((value) => {
-			console.log(value);
-		});
-		this.userService.userSubject.subscribe((user:any) => {
-			this.currentUserIntra = user.intra_name;
-			this.currentAvatarUrl = user.avatar_url;
-			this.initialTwoFactorState = user.two_factor_enabled;
-			this.settingsForm.patchValue({'twoFactorEnabled': this.initialTwoFactorState});
-		});
 	}
 }


### PR DESCRIPTION
 to prevent 2fa switching from disabled->enable if enabled
 
 steps to test:
 1. Go to settings page
 2. Click on enable 2fa and walk through the process to enable it
 3. Save changes
 4. switch to a different tab and back to settings
 
 Previously the 2fa enabled/disabled slider would show disabled for a second before switching to enabled
 the resolver makes sure the page loads once the 2fa status is known to the component